### PR TITLE
fix-build-info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 .idea/
 bin/
-build
+/build

--- a/Makefile
+++ b/Makefile
@@ -1,15 +1,15 @@
 
 GIT_SHA=$(shell git rev-parse HEAD)
 DATE=$(shell date -u +'%Y-%m-%dT%H:%M:%SZ')
-BUILD_INFO_IMPORT_PATH=github.com/dashbase/watch-append/pkg/build
+BUILD_INFO_IMPORT_PATH=night-watch/pkg/build
 BUILD_INFO=-ldflags "-X $(BUILD_INFO_IMPORT_PATH).commitSHA=$(GIT_SHA) -X $(BUILD_INFO_IMPORT_PATH).date=$(DATE)"
 
 
 
 .PHONY: build
 build_linux: build
-	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build -o ./build/nightwatch ./main.go
+	CGO_ENABLED=0 GOOS=linux installsuffix=cgo go build $(BUILD_INFO) -o ./build/nightwatch ./main.go
 
 build_mac: build
-	GOOS=darwin go build -o ./build/nightwatch-mac ./main.go
+	GOOS=darwin go build $(BUILD_INFO) -o ./build/nightwatch-mac ./main.go
 


### PR DESCRIPTION
```
➜  night-watch git:(fix-build-info) ✗ make build_mac                
GOOS=darwin go build -ldflags "-X night-watch/pkg/build.commitSHA=5f8435e639d4ae163eff2a8ccfe13363fecd276e -X night-watch/pkg/build.date=2018-12-17T07:07:30Z" -o ./build/nightwatch-mac ./main.go
➜  night-watch git:(fix-build-info) ✗ ./build/nightwatch-mac version
NightWatch BuildDate: 2018-12-17T07:07:30Z, commit: 5f8435e639d4ae163eff2a8ccfe13363fecd276e
```